### PR TITLE
CI: Add action to auto deploy to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+# Create a file called .github/workflows/auto-publish-spec-1.yml
+name: Auto Deployment
+on:
+  push:
+    branches: [master]
+
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: bikeshed
+          SOURCE: src/operator-question-mark.bs
+          DESTINATION: index.html
+          GH_PAGES_BRANCH: gh-pages


### PR DESCRIPTION
This can probably be merged now... I think it will just push to the `gh-pages` branch. 